### PR TITLE
Use string variable instead of boolean one

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Module Input Variables
 - `route_table_ids` - (optional) A comma separated list of route tables ids. This must be provided if you plan to create static routes for the destination_cidr_blocks in each route table.
 - `route_table_count` - (optional) The total number of tables in the route_table_ids list. This must be provided if route_table_ids is set. This is necessary since value of `count` cannot be computed in modules.
 - `static_routes_only` - Determines whether routes learned from BGP will be propagated to route tables. If set to true, you must have vgw route propagation enabled on route tables, and of course you must be running BGP. Accepts true or false.
-- `add_static_routes_to_tables` - Determines whether static routes will be added to all route tables in route_table_ids list or if vgw route propagation will be used instead. If set to true, then route_table_ids, route_table_count, and destination_cidr_blocks must also be provided.
+- `add_static_routes_to_tables` - Determines whether static routes will be added to all route tables in route_table_ids list or if vgw route propagation will be used instead. If set to "true", then route_table_ids, route_table_count, and destination_cidr_blocks must also be provided.
 
 Usage 
 -----
@@ -55,7 +55,7 @@ module "stockholm_cgw" {
   bgp_asn            = "65000"
   static_routes_only = true
 
-  add_static_routes_to_tables  = true
+  add_static_routes_to_tables  = "true"
   route_table_ids              = "${concat(module.public_subnet.public_route_table_ids, module.private_subnet.private_route_table_ids)}"
   route_table_count            = 6
   destination_cidr_blocks      = ["10.1.1.0/24", "10.100.1.0/24"]

--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,25 @@ resource "aws_customer_gateway" "default" {
 }
 
 resource "aws_vpn_connection" "default" {
+  count      = "${var.customer_gateway_id == "" ? 1 : 0}"
   vpn_gateway_id      = "${var.vpn_gateway_id}"
-  customer_gateway_id = "${var.customer_gateway_id == "" ? aws_customer_gateway.default.id : var.customer_gateway_id}"
+  customer_gateway_id = "${aws_customer_gateway.default.id}"
+  type                = "ipsec.1"
+  static_routes_only  = "${var.static_routes_only}"
+
+  tags {
+    Name = "${var.name}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpn_connection" "default" {
+  count      = "${var.customer_gateway_id == "" ? 0 : 1}"
+  vpn_gateway_id      = "${var.vpn_gateway_id}"
+  customer_gateway_id = "${aws_customer_gateway.default.id}"
   type                = "ipsec.1"
   static_routes_only  = "${var.static_routes_only}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 resource "aws_customer_gateway" "default" {
+  count      = "${var.customer_gateway_id == "" ? 1 : 0}"
   bgp_asn    = "${var.bgp_asn}"
   ip_address = "${var.ip_address}"
   type       = "ipsec.1"
@@ -14,7 +15,7 @@ resource "aws_customer_gateway" "default" {
 
 resource "aws_vpn_connection" "default" {
   vpn_gateway_id      = "${var.vpn_gateway_id}"
-  customer_gateway_id = "${aws_customer_gateway.default.id}"
+  customer_gateway_id = "${var.customer_gateway_id == "" ? aws_customer_gateway.default.id : var.customer_gateway_id}"
   type                = "ipsec.1"
   static_routes_only  = "${var.static_routes_only}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 resource "aws_customer_gateway" "default" {
+  count      = "${var.customer_gateway_id == "" ? 1 : 0}"
   bgp_asn    = "${var.bgp_asn}"
   ip_address = "${var.ip_address}"
   type       = "ipsec.1"
@@ -14,7 +15,7 @@ resource "aws_customer_gateway" "default" {
 
 resource "aws_vpn_connection" "default" {
   vpn_gateway_id      = "${var.vpn_gateway_id}"
-  customer_gateway_id = "${aws_customer_gateway.default.id}"
+  customer_gateway_id = "${coalesce(var.customer_gateway_id, aws_customer_gateway.default.id)}"
   type                = "ipsec.1"
   static_routes_only  = "${var.static_routes_only}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
 resource "aws_customer_gateway" "default" {
-  count      = "${var.customer_gateway_id == "" ? 1 : 0}"
   bgp_asn    = "${var.bgp_asn}"
   ip_address = "${var.ip_address}"
   type       = "ipsec.1"
@@ -14,23 +13,6 @@ resource "aws_customer_gateway" "default" {
 }
 
 resource "aws_vpn_connection" "default" {
-  count      = "${var.customer_gateway_id == "" ? 1 : 0}"
-  vpn_gateway_id      = "${var.vpn_gateway_id}"
-  customer_gateway_id = "${aws_customer_gateway.default.id}"
-  type                = "ipsec.1"
-  static_routes_only  = "${var.static_routes_only}"
-
-  tags {
-    Name = "${var.name}"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_vpn_connection" "default" {
-  count      = "${var.customer_gateway_id == "" ? 0 : 1}"
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${aws_customer_gateway.default.id}"
   type                = "ipsec.1"

--- a/vars.tf
+++ b/vars.tf
@@ -4,6 +4,12 @@ variable "name" {
 
 variable "vpn_gateway_id" {
   description = "Specify which VPN Gateway the Customer Gateway will be associated with."
+  default = ""
+}
+
+
+variable "customer_gateway_id" {
+  description = "Specify which Customer Gateway to use. If specified the variables ip_address and bgp_asn will not be used"
 }
 
 variable "ip_address" {

--- a/vars.tf
+++ b/vars.tf
@@ -19,7 +19,7 @@ variable "ip_address" {
 
 variable "bgp_asn" {
   description = "BGP ASN of the Customer Gateway. By convention, use 65000 if you are not running BGP."
-  default = ""
+  default = 65000
 }
 
 variable "destination_cidr_blocks" {

--- a/vars.tf
+++ b/vars.tf
@@ -4,20 +4,22 @@ variable "name" {
 
 variable "vpn_gateway_id" {
   description = "Specify which VPN Gateway the Customer Gateway will be associated with."
-  default = ""
 }
 
 
 variable "customer_gateway_id" {
   description = "Specify which Customer Gateway to use. If specified the variables ip_address and bgp_asn will not be used"
+  default = ""
 }
 
 variable "ip_address" {
   description = "IP address of the Customer Gateway external interface."
+  default = ""
 }
 
 variable "bgp_asn" {
   description = "BGP ASN of the Customer Gateway. By convention, use 65000 if you are not running BGP."
+  default = ""
 }
 
 variable "destination_cidr_blocks" {


### PR DESCRIPTION
'add_static_routes_to_tables = true' won't work with current code because of an explicit comparison with the "true" string.  
HashCorp recommends to refrain from using boolean variables for now: https://www.terraform.io/docs/configuration/variables.html