### PR TITLE
Customer Gateway: you can either create a new CGW or use an existing one

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ module "stockholm_cgw" {
   destination_cidr_blocks      = ["10.1.1.0/24", "10.100.1.0/24"]
 }
 
+# Or if you want to use existing CGW...
+/*
+module "stockholm_cgw" {
+  source = "github.com/terraform-community-modules/tf_aws_customer_gw"
+
+  name = "stockholm"
+
+  vpn_gateway_id      = "${module.vpn.vgw_id}"
+  customer_gateway_id = "<pass the CGW ID e.g. from a data block>"
+  static_routes_only = true
+
+  add_static_routes_to_tables  = true
+  route_table_ids              = "${concat(module.public_subnet.public_route_table_ids, module.private_subnet.private_route_table_ids)}"
+  route_table_count            = 6
+  destination_cidr_blocks      = ["10.1.1.0/24", "10.100.1.0/24"]
+}
+*/
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Module Input Variables
 
 - `name`   - Unique name used to label the VPN Gateway and Customer Gateway.
 - `vpn_gateway_id` - VPN Gateway to associate with Customer Gateway and VPN Connection.
-- `ip_address` - The IP address of the gateway's Internet-routable external interface.
-- `bgp_asn` - BGP Autonomous System Number. If BGP is not in use, then by convention set this value to 65000.
+-  Customer Gateway (CGW): you can use an existing CGW or you can create a new CGW
+   - To use existing CGW: pass the CGW ID in `customer_gateway_id`. In this case `ip_address` and `bagp_asn` are not relevant and not used
+   - To create a new CGW: leave `customer_gateway_id` as "", and specify 2 variables below:
+     - `ip_address` - The IP address of the gateway's Internet-routable external interface.
+     - `bgp_asn` - BGP Autonomous System Number. If BGP is not in use, then by convention set this value to 65000.
 - `destination_cidr_blocks` - A comma separated list of CIDR blocks which sit behind the Customer Gateway device and should be routed over the VPN connection.
 - `route_table_ids` - (optional) A comma separated list of route tables ids. This must be provided if you plan to create static routes for the destination_cidr_blocks in each route table.
 - `route_table_count` - (optional) The total number of tables in the route_table_ids list. This must be provided if route_table_ids is set. This is necessary since value of `count` cannot be computed in modules.

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 resource "aws_customer_gateway" "default" {
+  count = "${var.customer_gateway_id == "" ? 1 : 0}"
   bgp_asn    = "${var.bgp_asn}"
   ip_address = "${var.ip_address}"
   type       = "ipsec.1"
@@ -14,7 +15,7 @@ resource "aws_customer_gateway" "default" {
 
 resource "aws_vpn_connection" "default" {
   vpn_gateway_id      = "${var.vpn_gateway_id}"
-  customer_gateway_id = "${aws_customer_gateway.default.id}"
+  customer_gateway_id = "${var.customer_gateway_id == "" ? join("", aws_customer_gateway.default.*.id) : var.customer_gateway_id}"
   type                = "ipsec.1"
   static_routes_only  = "${var.static_routes_only}"
 

--- a/vars.tf
+++ b/vars.tf
@@ -18,7 +18,7 @@ variable "ip_address" {
 
 variable "bgp_asn" {
   description = "BGP ASN of the Customer Gateway. By convention, use 65000 if you are not running BGP. Not used if customer_gateway_id is specified"
-  default = 0
+  default = 65000
 }
 
 variable "destination_cidr_blocks" {

--- a/vars.tf
+++ b/vars.tf
@@ -6,12 +6,19 @@ variable "vpn_gateway_id" {
   description = "Specify which VPN Gateway the Customer Gateway will be associated with."
 }
 
+variable "customer_gateway_id" {
+  description = "The CGW Id to be used to form the VPN connection. If not specified a new CGW is created"
+  default = ""
+}
+
 variable "ip_address" {
-  description = "IP address of the Customer Gateway external interface."
+  description = "IP address of the Customer Gateway external interface. Not used if customer_gateway_id is specified"
+  default = ""
 }
 
 variable "bgp_asn" {
-  description = "BGP ASN of the Customer Gateway. By convention, use 65000 if you are not running BGP."
+  description = "BGP ASN of the Customer Gateway. By convention, use 65000 if you are not running BGP. Not used if customer_gateway_id is specified"
+  default = 0
 }
 
 variable "destination_cidr_blocks" {


### PR DESCRIPTION
My use case is I have a single Customer Gateway (CGW) on-premises, but I have multiple VPCs.
I'd like to use the CGW to create multiple VPNs to the VPCs.

This pull request is to allow to use an existing CGW